### PR TITLE
fix: pin GitHub Actions to full SHA (CLOUDEVOPS-4942)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.8'
       - name: Build SDK
@@ -15,7 +15,7 @@ jobs:
           export BUILD_JOB_ID=$GITHUB_RUN_ID
           pip install .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: chkp_harmony_endpoint_management_cli
           path: chkp_harmony_endpoint_management_cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
     - name: Set up Python 3.9
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: 3.9
     - name: Build Package
@@ -35,6 +35,6 @@ jobs:
         .
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## External Actions (pinned to SHA)

**actions**

- `actions/checkout@master` → `61b9e37` · [verify](https://github.com/actions/checkout/commit/61b9e3751b92087fd0b06925ba6dd6314e06f089)
- `actions/checkout@v4` → `34e1148` · [verify](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5)
- `actions/setup-python@v5` → `a26af69` · [verify](https://github.com/actions/setup-python/commit/a26af69be951a213d495a4c3e4e4022e16d87065)
- `actions/upload-artifact@v4` → `ea165f8` · [verify](https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02)

**pypa**

- `pypa/gh-action-pypi-publish@release/v1` → `ed0c539` · [verify](https://github.com/pypa/gh-action-pypi-publish/commit/ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e)